### PR TITLE
CookieAuth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+.idea/
+*.iml

--- a/resource.go
+++ b/resource.go
@@ -243,6 +243,8 @@ func request(method string, u *url.URL, header http.Header, body io.Reader, para
 	setDefault(&req.Header, "Accept", "application/json")
 	setDefault(&req.Header, "Content-Type", "application/json")
 	updateHeader(&req.Header, &header)
+	updateHeader(&req.Header, cookieAuthHeader)
+
 	rsp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This PR caches the token obtained from Server.Login and uses it to authenticate future requests. 
As soon as Server.Logout is called the Cookie is cleared again.