### PR TITLE
Fix nil pointer exception thrown when total_rows is missing

### DIFF
--- a/design.go
+++ b/design.go
@@ -150,10 +150,6 @@ func (vr *ViewResults) fetch() ([]Row, error) {
 		return nil, err
 	}
 
-	var totalRows float64
-	json.Unmarshal(*jsonMap["total_rows"], &totalRows)
-	vr.totalRows = int(totalRows)
-
 	if offsetRaw, ok := jsonMap["offset"]; ok {
 		var offset float64
 		json.Unmarshal(*offsetRaw, &offset)
@@ -168,6 +164,7 @@ func (vr *ViewResults) fetch() ([]Row, error) {
 
 	var rowsRaw []*json.RawMessage
 	json.Unmarshal(*jsonMap["rows"], &rowsRaw)
+	vr.totalRows = len(rowsRaw)
 
 	rows := make([]Row, len(rowsRaw))
 	var rowMap map[string]interface{}


### PR DESCRIPTION
Using couchdb 1.6.1, I get a null pointer exception on querying views that contain a reduce function, because apparently they do not return the key "total_rows" in the json response ("invalid memory address or nil pointer dereference" - "github.com/leesper/couchdb-golang/design.go:154"). I found this fix handy